### PR TITLE
プロフィール表示/編集画面イメージの作成

### DIFF
--- a/documents/ScreenDesigns/プロフィール編集画面.drawio
+++ b/documents/ScreenDesigns/プロフィール編集画面.drawio
@@ -1,0 +1,58 @@
+<mxfile host="65bd71144e">
+    <diagram id="WWbYQ2NUVVgn80VWuXI2" name="ページ1">
+        <mxGraphModel dx="2555" dy="1395" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="2" value="&lt;div class=&quot;sessionsLayoutHeader_title&quot; style=&quot;box-sizing: inherit ; margin: 30px 0px ; letter-spacing: 1px ; font-size: 36px ; font-weight: 400 ; color: rgb(74 , 74 , 74) ; font-style: normal ; text-indent: 0px ; text-transform: none ; word-spacing: 0px ; background-color: rgb(255 , 255 , 255)&quot;&gt;&lt;br&gt;&lt;/div&gt;" style="html=1;shadow=0;dashed=0;fontSize=16;align=left;spacing=15;container=0;fillColor=#fff;fontColor=#333333;strokeColor=#666666;" parent="1" vertex="1">
+                    <mxGeometry y="-1" width="1600" height="900" as="geometry"/>
+                </mxCell>
+                <mxCell id="13" value="" style="endArrow=none;html=1;strokeColor=#5c93bb2b;strokeWidth=3;entryX=1;entryY=0.067;entryDx=0;entryDy=0;entryPerimeter=0;exitX=-0.001;exitY=0.069;exitDx=0;exitDy=0;exitPerimeter=0;" parent="1" source="2" target="2" edge="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="-0.4" y="70" as="sourcePoint"/>
+                        <mxPoint x="1759.6" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="14" value="ロゴ" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=3;fillColor=#dae8fc;strokeColor=#6c8ebf;fontStyle=1;fontSize=26;labelBackgroundColor=none;fontColor=#301AF0;" parent="1" vertex="1">
+                    <mxGeometry x="39.6" y="10" width="120" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="15" value="ユーザー名 / テストテストテストテストテス" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;rounded=0;labelBackgroundColor=none;fontSize=18;fontColor=#000000d1;horizontal=1;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+                    <mxGeometry x="605" y="187" width="390" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="18" value="自己紹介メッセージ / テストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテ" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;rounded=0;labelBackgroundColor=none;fontSize=12;fontColor=#000000d1;horizontal=1;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+                    <mxGeometry x="605" y="220" width="390" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="23" value="フォロー中" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#FFFFFF;strokeColor=#3EA8FF;align=center;spacing=15;fontSize=14;fontColor=#3EA8FF;" parent="1" vertex="1">
+                    <mxGeometry x="1630" y="115" width="120" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="22" value="フォロー" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#3EA8FF;strokeColor=#FFFFFF;align=center;spacing=15;fontSize=14;fontColor=#FFFFFF;fontStyle=1" parent="1" vertex="1">
+                    <mxGeometry x="1630" y="170" width="120" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="20" value="&lt;font style=&quot;font-size: 12px&quot;&gt;プロフィール編集&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=#6c767d;align=center;spacing=15;fontSize=14;fontColor=#6c767d;" parent="1" vertex="1">
+                    <mxGeometry x="870" y="150" width="120" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="25" value="" style="verticalLabelPosition=bottom;shadow=0;dashed=0;align=center;html=1;verticalAlign=top;strokeWidth=1;shape=mxgraph.mockup.containers.userFemale;strokeColor=#666666;strokeColor2=#008cff;fontSize=12;fontColor=#FFFFFF;fillColor=#3EA8FF;" parent="1" vertex="1">
+                    <mxGeometry x="610" y="90" width="90" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="71" value="記事作成" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#3EA8FF;strokeColor=#FFFFFF;align=center;spacing=15;fontSize=14;fontColor=#FFFFFF;fontStyle=1" parent="1" vertex="1">
+                    <mxGeometry x="1445" y="15" width="120" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="73" value="&lt;font style=&quot;font-size: 12px&quot;&gt;50 フォロワー&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=none;align=center;spacing=15;fontSize=12;fontColor=#6c767d;" parent="1" vertex="1">
+                    <mxGeometry x="740" y="300" width="120" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="77" value="" style="group" parent="1" vertex="1" connectable="0">
+                    <mxGeometry x="603" y="300" width="395" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="75" value="&lt;font style=&quot;font-size: 12px&quot;&gt;投稿 6&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=none;align=center;spacing=15;fontSize=12;fontColor=#6c767d;" parent="77" vertex="1">
+                    <mxGeometry width="130" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="76" value="&lt;font style=&quot;font-size: 12px&quot;&gt;フォロー 50&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=none;align=center;spacing=15;fontSize=12;fontColor=#6c767d;" parent="77" vertex="1">
+                    <mxGeometry x="130" width="130" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="74" value="&lt;font style=&quot;font-size: 12px&quot;&gt;フォロワー 50&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=none;align=center;spacing=15;fontSize=12;fontColor=#6c767d;" parent="77" vertex="1">
+                    <mxGeometry x="260" width="130" height="30" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/documents/ScreenDesigns/プロフィール編集画面.drawio
+++ b/documents/ScreenDesigns/プロフィール編集画面.drawio
@@ -1,6 +1,6 @@
 <mxfile host="65bd71144e">
     <diagram id="WWbYQ2NUVVgn80VWuXI2" name="ページ1">
-        <mxGraphModel dx="2655" dy="1444" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
+        <mxGraphModel dx="2655" dy="1308" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>
@@ -34,7 +34,7 @@
                 <mxCell id="87" value="自己紹介メッセージ / テストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテ" style="text;strokeColor=#999999;fillColor=#F1F5F9;align=left;verticalAlign=top;rounded=1;labelBackgroundColor=none;fontSize=12;fontColor=#6C767D;horizontal=1;whiteSpace=wrap;html=1;arcSize=5;opacity=80;" vertex="1" parent="1">
                     <mxGeometry x="605" y="230" width="385" height="90" as="geometry"/>
                 </mxCell>
-                <mxCell id="89" value="退会する" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#d80073;strokeColor=#A50040;align=center;spacing=15;fontSize=14;fontColor=#ffffff;fontStyle=1" vertex="1" parent="1">
+                <mxCell id="89" value="退会する" style="html=1;shadow=0;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#d80073;strokeColor=#A50040;align=center;spacing=15;fontSize=14;fontColor=#ffffff;fontStyle=1" vertex="1" parent="1">
                     <mxGeometry x="870" y="435" width="120" height="30" as="geometry"/>
                 </mxCell>
             </root>

--- a/documents/ScreenDesigns/プロフィール編集画面.drawio
+++ b/documents/ScreenDesigns/プロフィール編集画面.drawio
@@ -1,6 +1,6 @@
 <mxfile host="65bd71144e">
     <diagram id="WWbYQ2NUVVgn80VWuXI2" name="ページ1">
-        <mxGraphModel dx="2254" dy="1329" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
+        <mxGraphModel dx="2729" dy="1345" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>
@@ -15,12 +15,6 @@
                 </mxCell>
                 <mxCell id="14" value="ロゴ" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=3;fillColor=#dae8fc;strokeColor=#6c8ebf;fontStyle=1;fontSize=26;labelBackgroundColor=none;fontColor=#301AF0;" parent="1" vertex="1">
                     <mxGeometry x="39.6" y="10" width="120" height="50" as="geometry"/>
-                </mxCell>
-                <mxCell id="23" value="フォロー中" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#FFFFFF;strokeColor=#3EA8FF;align=center;spacing=15;fontSize=14;fontColor=#3EA8FF;" parent="1" vertex="1">
-                    <mxGeometry x="1630" y="115" width="120" height="30" as="geometry"/>
-                </mxCell>
-                <mxCell id="22" value="フォロー" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#3EA8FF;strokeColor=#FFFFFF;align=center;spacing=15;fontSize=14;fontColor=#FFFFFF;fontStyle=1" parent="1" vertex="1">
-                    <mxGeometry x="1630" y="170" width="120" height="30" as="geometry"/>
                 </mxCell>
                 <mxCell id="20" value="&lt;font style=&quot;font-size: 12px&quot;&gt;編集を保存&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=#6c767d;align=center;spacing=15;fontSize=14;fontColor=#6c767d;" parent="1" vertex="1">
                     <mxGeometry x="870" y="150" width="120" height="30" as="geometry"/>

--- a/documents/ScreenDesigns/プロフィール編集画面.drawio
+++ b/documents/ScreenDesigns/プロフィール編集画面.drawio
@@ -1,6 +1,6 @@
 <mxfile host="65bd71144e">
     <diagram id="WWbYQ2NUVVgn80VWuXI2" name="ページ1">
-        <mxGraphModel dx="2555" dy="1395" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
+        <mxGraphModel dx="2254" dy="1329" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>
@@ -16,19 +16,13 @@
                 <mxCell id="14" value="ロゴ" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=3;fillColor=#dae8fc;strokeColor=#6c8ebf;fontStyle=1;fontSize=26;labelBackgroundColor=none;fontColor=#301AF0;" parent="1" vertex="1">
                     <mxGeometry x="39.6" y="10" width="120" height="50" as="geometry"/>
                 </mxCell>
-                <mxCell id="15" value="ユーザー名 / テストテストテストテストテス" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;rounded=0;labelBackgroundColor=none;fontSize=18;fontColor=#000000d1;horizontal=1;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-                    <mxGeometry x="605" y="187" width="390" height="40" as="geometry"/>
-                </mxCell>
-                <mxCell id="18" value="自己紹介メッセージ / テストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテ" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;rounded=0;labelBackgroundColor=none;fontSize=12;fontColor=#000000d1;horizontal=1;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-                    <mxGeometry x="605" y="220" width="390" height="60" as="geometry"/>
-                </mxCell>
                 <mxCell id="23" value="フォロー中" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#FFFFFF;strokeColor=#3EA8FF;align=center;spacing=15;fontSize=14;fontColor=#3EA8FF;" parent="1" vertex="1">
                     <mxGeometry x="1630" y="115" width="120" height="30" as="geometry"/>
                 </mxCell>
                 <mxCell id="22" value="フォロー" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#3EA8FF;strokeColor=#FFFFFF;align=center;spacing=15;fontSize=14;fontColor=#FFFFFF;fontStyle=1" parent="1" vertex="1">
                     <mxGeometry x="1630" y="170" width="120" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="20" value="&lt;font style=&quot;font-size: 12px&quot;&gt;プロフィール編集&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=#6c767d;align=center;spacing=15;fontSize=14;fontColor=#6c767d;" parent="1" vertex="1">
+                <mxCell id="20" value="&lt;font style=&quot;font-size: 12px&quot;&gt;編集を保存&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=#6c767d;align=center;spacing=15;fontSize=14;fontColor=#6c767d;" parent="1" vertex="1">
                     <mxGeometry x="870" y="150" width="120" height="30" as="geometry"/>
                 </mxCell>
                 <mxCell id="25" value="" style="verticalLabelPosition=bottom;shadow=0;dashed=0;align=center;html=1;verticalAlign=top;strokeWidth=1;shape=mxgraph.mockup.containers.userFemale;strokeColor=#666666;strokeColor2=#008cff;fontSize=12;fontColor=#FFFFFF;fillColor=#3EA8FF;" parent="1" vertex="1">
@@ -37,20 +31,14 @@
                 <mxCell id="71" value="記事作成" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#3EA8FF;strokeColor=#FFFFFF;align=center;spacing=15;fontSize=14;fontColor=#FFFFFF;fontStyle=1" parent="1" vertex="1">
                     <mxGeometry x="1445" y="15" width="120" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="73" value="&lt;font style=&quot;font-size: 12px&quot;&gt;50 フォロワー&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=none;align=center;spacing=15;fontSize=12;fontColor=#6c767d;" parent="1" vertex="1">
-                    <mxGeometry x="740" y="300" width="120" height="30" as="geometry"/>
+                <mxCell id="80" value="&lt;font style=&quot;font-size: 10px;&quot;&gt;変更する&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=#6c767d;align=center;spacing=15;fontSize=10;fontColor=#6c767d;gradientColor=none;opacity=80;" vertex="1" parent="1">
+                    <mxGeometry x="630" y="155" width="50" height="20" as="geometry"/>
                 </mxCell>
-                <mxCell id="77" value="" style="group" parent="1" vertex="1" connectable="0">
-                    <mxGeometry x="603" y="300" width="395" height="30" as="geometry"/>
+                <mxCell id="85" value="&lt;span style=&quot;font-size: 18px&quot;&gt;&lt;font&gt;ユーザー名 / テストテストテストテストテス&lt;/font&gt;&lt;/span&gt;" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#f1f5f9;strokeColor=#999999;align=left;spacing=2;fontSize=14;fontColor=#6C767D;rounded=0;opacity=80;spacingTop=5;" vertex="1" parent="1">
+                    <mxGeometry x="605" y="190" width="385" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="75" value="&lt;font style=&quot;font-size: 12px&quot;&gt;投稿 6&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=none;align=center;spacing=15;fontSize=12;fontColor=#6c767d;" parent="77" vertex="1">
-                    <mxGeometry width="130" height="30" as="geometry"/>
-                </mxCell>
-                <mxCell id="76" value="&lt;font style=&quot;font-size: 12px&quot;&gt;フォロー 50&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=none;align=center;spacing=15;fontSize=12;fontColor=#6c767d;" parent="77" vertex="1">
-                    <mxGeometry x="130" width="130" height="30" as="geometry"/>
-                </mxCell>
-                <mxCell id="74" value="&lt;font style=&quot;font-size: 12px&quot;&gt;フォロワー 50&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=none;align=center;spacing=15;fontSize=12;fontColor=#6c767d;" parent="77" vertex="1">
-                    <mxGeometry x="260" width="130" height="30" as="geometry"/>
+                <mxCell id="87" value="自己紹介メッセージ / テストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテ" style="text;strokeColor=#999999;fillColor=#F1F5F9;align=left;verticalAlign=top;rounded=1;labelBackgroundColor=none;fontSize=12;fontColor=#6C767D;horizontal=1;whiteSpace=wrap;html=1;arcSize=5;opacity=80;" vertex="1" parent="1">
+                    <mxGeometry x="605" y="230" width="385" height="90" as="geometry"/>
                 </mxCell>
             </root>
         </mxGraphModel>

--- a/documents/ScreenDesigns/プロフィール編集画面.drawio
+++ b/documents/ScreenDesigns/プロフィール編集画面.drawio
@@ -1,6 +1,6 @@
 <mxfile host="65bd71144e">
     <diagram id="WWbYQ2NUVVgn80VWuXI2" name="ページ1">
-        <mxGraphModel dx="2729" dy="1345" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
+        <mxGraphModel dx="2655" dy="1444" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>
@@ -33,6 +33,9 @@
                 </mxCell>
                 <mxCell id="87" value="自己紹介メッセージ / テストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテ" style="text;strokeColor=#999999;fillColor=#F1F5F9;align=left;verticalAlign=top;rounded=1;labelBackgroundColor=none;fontSize=12;fontColor=#6C767D;horizontal=1;whiteSpace=wrap;html=1;arcSize=5;opacity=80;" vertex="1" parent="1">
                     <mxGeometry x="605" y="230" width="385" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="89" value="退会する" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#d80073;strokeColor=#A50040;align=center;spacing=15;fontSize=14;fontColor=#ffffff;fontStyle=1" vertex="1" parent="1">
+                    <mxGeometry x="870" y="435" width="120" height="30" as="geometry"/>
                 </mxCell>
             </root>
         </mxGraphModel>

--- a/documents/ScreenDesigns/プロフィール表示画面.drawio
+++ b/documents/ScreenDesigns/プロフィール表示画面.drawio
@@ -1,0 +1,137 @@
+<mxfile host="65bd71144e">
+    <diagram id="WWbYQ2NUVVgn80VWuXI2" name="ページ1">
+        <mxGraphModel dx="2980" dy="1616" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="2" value="&lt;div class=&quot;sessionsLayoutHeader_title&quot; style=&quot;box-sizing: inherit ; margin: 30px 0px ; letter-spacing: 1px ; font-size: 36px ; font-weight: 400 ; color: rgb(74 , 74 , 74) ; font-style: normal ; text-indent: 0px ; text-transform: none ; word-spacing: 0px ; background-color: rgb(255 , 255 , 255)&quot;&gt;&lt;br&gt;&lt;/div&gt;" style="html=1;shadow=0;dashed=0;fontSize=16;align=left;spacing=15;container=0;fillColor=#fff;fontColor=#333333;strokeColor=#666666;" vertex="1" parent="1">
+                    <mxGeometry y="-1" width="1600" height="900" as="geometry"/>
+                </mxCell>
+                <mxCell id="13" value="" style="endArrow=none;html=1;strokeColor=#5c93bb2b;strokeWidth=3;entryX=1;entryY=0.067;entryDx=0;entryDy=0;entryPerimeter=0;exitX=-0.001;exitY=0.069;exitDx=0;exitDy=0;exitPerimeter=0;" edge="1" parent="1" source="2" target="2">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="-0.4" y="70" as="sourcePoint"/>
+                        <mxPoint x="1759.6" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="14" value="ロゴ" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=3;fillColor=#dae8fc;strokeColor=#6c8ebf;fontStyle=1;fontSize=26;labelBackgroundColor=none;fontColor=#301AF0;" vertex="1" parent="1">
+                    <mxGeometry x="39.6" y="10" width="120" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="15" value="ユーザー名 / テストテストテストテストテス" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;rounded=0;labelBackgroundColor=none;fontSize=18;fontColor=#000000d1;horizontal=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+                    <mxGeometry x="605" y="187" width="390" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="18" value="自己紹介メッセージ / テストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテ" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;rounded=0;labelBackgroundColor=none;fontSize=12;fontColor=#000000d1;horizontal=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+                    <mxGeometry x="605" y="220" width="390" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="23" value="フォロー中" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#FFFFFF;strokeColor=#3EA8FF;align=center;spacing=15;fontSize=14;fontColor=#3EA8FF;" vertex="1" parent="1">
+                    <mxGeometry x="1630" y="115" width="120" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="22" value="フォロー" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#3EA8FF;strokeColor=#FFFFFF;align=center;spacing=15;fontSize=14;fontColor=#FFFFFF;fontStyle=1" vertex="1" parent="1">
+                    <mxGeometry x="1630" y="170" width="120" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="20" value="&lt;font style=&quot;font-size: 12px&quot;&gt;プロフィール編集&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=#6c767d;align=center;spacing=15;fontSize=14;fontColor=#6c767d;" vertex="1" parent="1">
+                    <mxGeometry x="870" y="150" width="120" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="25" value="" style="verticalLabelPosition=bottom;shadow=0;dashed=0;align=center;html=1;verticalAlign=top;strokeWidth=1;shape=mxgraph.mockup.containers.userFemale;strokeColor=#666666;strokeColor2=#008cff;fontSize=12;fontColor=#FFFFFF;fillColor=#3EA8FF;" vertex="1" parent="1">
+                    <mxGeometry x="610" y="90" width="90" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="71" value="記事作成" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#3EA8FF;strokeColor=#FFFFFF;align=center;spacing=15;fontSize=14;fontColor=#FFFFFF;fontStyle=1" vertex="1" parent="1">
+                    <mxGeometry x="1445" y="15" width="120" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="72" value="" style="group" vertex="1" connectable="0" parent="1">
+                    <mxGeometry x="-1.9999999999998863" y="330" width="1601.6" height="510" as="geometry"/>
+                </mxCell>
+                <mxCell id="26" value="" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;rSize=5;strokeColor=none;html=1;whiteSpace=wrap;fillColor=#FFFFFF;fontColor=#000000;fontSize=12;strokeWidth=1;align=center;" vertex="1" parent="72">
+                    <mxGeometry x="434.9999999999999" width="730" height="510" as="geometry"/>
+                </mxCell>
+                <mxCell id="27" value="" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.topButton;strokeColor=inherit;fillColor=none;rSize=5;perimeter=none;whiteSpace=wrap;resizeWidth=1;align=center;spacing=20;fontSize=14;fontColor=#FFFFFF;" vertex="1" parent="26">
+                    <mxGeometry width="620" height="50" relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="31" value="&lt;span style=&quot;font-size: 20px&quot;&gt;&lt;b&gt;レシピ一覧&lt;/b&gt;&lt;/span&gt;" style="perimeter=none;html=1;whiteSpace=wrap;fillColor=none;strokeColor=none;resizeWidth=1;verticalAlign=top;align=left;spacing=20;spacingTop=-10;fontSize=14;fontColor=#212529;dashed=1;" vertex="1" parent="26">
+                    <mxGeometry width="620" height="120" relative="1" as="geometry">
+                        <mxPoint y="50" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="56" value="" style="group" vertex="1" connectable="0" parent="26">
+                    <mxGeometry x="65" y="120" width="600" height="180" as="geometry"/>
+                </mxCell>
+                <mxCell id="40" value="" style="shadow=0;dashed=0;shape=mxgraph.bootstrap.rightButton;rSize=5;strokeColor=#DFDFDF;fillColor=#ffffff;fontColor=#000000;verticalAlign=top;align=left;spacing=20;spacingBottom=0;fontSize=14;spacingTop=160;" vertex="1" parent="56">
+                    <mxGeometry width="180" height="180" as="geometry">
+                        <mxPoint x="-10" y="-210" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="41" value="Image cap" style="html=1;shadow=0;dashed=0;shape=mxgraph.basic.corner_round_rect;dx=2;flipH=1;perimeter=none;whiteSpace=wrap;fillColor=#3EA8FF;strokeColor=#DFDFDF;fontColor=#DEE2E6;resizeWidth=1;fontSize=18;" vertex="1" parent="40">
+                    <mxGeometry width="180" height="50" relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="52" value="" style="shadow=0;dashed=0;shape=mxgraph.bootstrap.rightButton;rSize=5;strokeColor=#DFDFDF;fillColor=#ffffff;fontColor=#000000;verticalAlign=top;align=left;spacing=20;spacingBottom=0;fontSize=14;spacingTop=160;" vertex="1" parent="56">
+                    <mxGeometry x="210" width="180" height="180" as="geometry">
+                        <mxPoint x="-10" y="-210" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="53" value="Image cap" style="html=1;shadow=0;dashed=0;shape=mxgraph.basic.corner_round_rect;dx=2;flipH=1;perimeter=none;whiteSpace=wrap;fillColor=#3EA8FF;strokeColor=#DFDFDF;fontColor=#DEE2E6;resizeWidth=1;fontSize=18;" vertex="1" parent="52">
+                    <mxGeometry width="180" height="50" relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="54" value="" style="shadow=0;dashed=0;shape=mxgraph.bootstrap.rightButton;rSize=5;strokeColor=#DFDFDF;fillColor=#ffffff;fontColor=#000000;verticalAlign=top;align=left;spacing=20;spacingBottom=0;fontSize=14;spacingTop=160;" vertex="1" parent="56">
+                    <mxGeometry x="420" width="180" height="180" as="geometry">
+                        <mxPoint x="-10" y="-210" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="55" value="Image cap" style="html=1;shadow=0;dashed=0;shape=mxgraph.basic.corner_round_rect;dx=2;flipH=1;perimeter=none;whiteSpace=wrap;fillColor=#3EA8FF;strokeColor=#DFDFDF;fontColor=#DEE2E6;resizeWidth=1;fontSize=18;" vertex="1" parent="54">
+                    <mxGeometry width="180" height="50" relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="64" value="" style="group" vertex="1" connectable="0" parent="26">
+                    <mxGeometry x="65" y="330" width="600" height="180" as="geometry"/>
+                </mxCell>
+                <mxCell id="65" value="" style="shadow=0;dashed=0;shape=mxgraph.bootstrap.rightButton;rSize=5;strokeColor=#DFDFDF;fillColor=#ffffff;fontColor=#000000;verticalAlign=top;align=left;spacing=20;spacingBottom=0;fontSize=14;spacingTop=160;" vertex="1" parent="64">
+                    <mxGeometry width="180" height="180" as="geometry">
+                        <mxPoint x="-10" y="-210" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="66" value="Image cap" style="html=1;shadow=0;dashed=0;shape=mxgraph.basic.corner_round_rect;dx=2;flipH=1;perimeter=none;whiteSpace=wrap;fillColor=#3EA8FF;strokeColor=#DFDFDF;fontColor=#DEE2E6;resizeWidth=1;fontSize=18;" vertex="1" parent="65">
+                    <mxGeometry width="180" height="50" relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="67" value="" style="shadow=0;dashed=0;shape=mxgraph.bootstrap.rightButton;rSize=5;strokeColor=#DFDFDF;fillColor=#ffffff;fontColor=#000000;verticalAlign=top;align=left;spacing=20;spacingBottom=0;fontSize=14;spacingTop=160;" vertex="1" parent="64">
+                    <mxGeometry x="210" width="180" height="180" as="geometry">
+                        <mxPoint x="-10" y="-210" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="68" value="Image cap" style="html=1;shadow=0;dashed=0;shape=mxgraph.basic.corner_round_rect;dx=2;flipH=1;perimeter=none;whiteSpace=wrap;fillColor=#3EA8FF;strokeColor=#DFDFDF;fontColor=#DEE2E6;resizeWidth=1;fontSize=18;" vertex="1" parent="67">
+                    <mxGeometry width="180" height="50" relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="69" value="" style="shadow=0;dashed=0;shape=mxgraph.bootstrap.rightButton;rSize=5;strokeColor=#DFDFDF;fillColor=#ffffff;fontColor=#000000;verticalAlign=top;align=left;spacing=20;spacingBottom=0;fontSize=14;spacingTop=160;" vertex="1" parent="64">
+                    <mxGeometry x="420" width="180" height="180" as="geometry">
+                        <mxPoint x="-10" y="-210" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="70" value="Image cap" style="html=1;shadow=0;dashed=0;shape=mxgraph.basic.corner_round_rect;dx=2;flipH=1;perimeter=none;whiteSpace=wrap;fillColor=#3EA8FF;strokeColor=#DFDFDF;fontColor=#DEE2E6;resizeWidth=1;fontSize=18;" vertex="1" parent="69">
+                    <mxGeometry width="180" height="50" relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="28" value="レシピ" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.tabTop;strokeColor=#DFDFDF;fillColor=#ffffff;rSize=5;perimeter=none;resizeWidth=1;align=center;spacing=20;fontSize=14;fontColor=#3EA8FF;" vertex="1" parent="26">
+                    <mxGeometry width="62" height="40" relative="1" as="geometry">
+                        <mxPoint x="10" y="11" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="34" value="" style="endArrow=none;html=1;strokeColor=#dfdfdf;strokeWidth=1;entryX=1;entryY=0.067;entryDx=0;entryDy=0;entryPerimeter=0;exitX=-0.001;exitY=0.069;exitDx=0;exitDy=0;exitPerimeter=0;" edge="1" parent="72">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint y="51.80000000000001" as="sourcePoint"/>
+                        <mxPoint x="1601.6" y="49.99999999999994" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="73" value="&lt;font style=&quot;font-size: 12px&quot;&gt;50 フォロワー&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=none;align=center;spacing=15;fontSize=12;fontColor=#6c767d;" vertex="1" parent="1">
+                    <mxGeometry x="740" y="300" width="120" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="77" value="" style="group" vertex="1" connectable="0" parent="1">
+                    <mxGeometry x="603" y="300" width="395" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="75" value="&lt;font style=&quot;font-size: 12px&quot;&gt;投稿 6&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=none;align=center;spacing=15;fontSize=12;fontColor=#6c767d;" vertex="1" parent="77">
+                    <mxGeometry width="130" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="76" value="&lt;font style=&quot;font-size: 12px&quot;&gt;フォロー 50&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=none;align=center;spacing=15;fontSize=12;fontColor=#6c767d;" vertex="1" parent="77">
+                    <mxGeometry x="130" width="130" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="74" value="&lt;font style=&quot;font-size: 12px&quot;&gt;フォロワー 50&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=none;align=center;spacing=15;fontSize=12;fontColor=#6c767d;" vertex="1" parent="77">
+                    <mxGeometry x="260" width="130" height="30" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/documents/ScreenDesigns/プロフィール表示画面.drawio
+++ b/documents/ScreenDesigns/プロフィール表示画面.drawio
@@ -1,132 +1,141 @@
 <mxfile host="65bd71144e">
     <diagram id="WWbYQ2NUVVgn80VWuXI2" name="ページ1">
-        <mxGraphModel dx="2980" dy="1616" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
+        <mxGraphModel dx="2635" dy="1580" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>
-                <mxCell id="2" value="&lt;div class=&quot;sessionsLayoutHeader_title&quot; style=&quot;box-sizing: inherit ; margin: 30px 0px ; letter-spacing: 1px ; font-size: 36px ; font-weight: 400 ; color: rgb(74 , 74 , 74) ; font-style: normal ; text-indent: 0px ; text-transform: none ; word-spacing: 0px ; background-color: rgb(255 , 255 , 255)&quot;&gt;&lt;br&gt;&lt;/div&gt;" style="html=1;shadow=0;dashed=0;fontSize=16;align=left;spacing=15;container=0;fillColor=#fff;fontColor=#333333;strokeColor=#666666;" vertex="1" parent="1">
+                <mxCell id="2" value="&lt;div class=&quot;sessionsLayoutHeader_title&quot; style=&quot;box-sizing: inherit ; margin: 30px 0px ; letter-spacing: 1px ; font-size: 36px ; font-weight: 400 ; color: rgb(74 , 74 , 74) ; font-style: normal ; text-indent: 0px ; text-transform: none ; word-spacing: 0px ; background-color: rgb(255 , 255 , 255)&quot;&gt;&lt;br&gt;&lt;/div&gt;" style="html=1;shadow=0;dashed=0;fontSize=16;align=left;spacing=15;container=0;fillColor=#fff;fontColor=#333333;strokeColor=#666666;" parent="1" vertex="1">
                     <mxGeometry y="-1" width="1600" height="900" as="geometry"/>
                 </mxCell>
-                <mxCell id="13" value="" style="endArrow=none;html=1;strokeColor=#5c93bb2b;strokeWidth=3;entryX=1;entryY=0.067;entryDx=0;entryDy=0;entryPerimeter=0;exitX=-0.001;exitY=0.069;exitDx=0;exitDy=0;exitPerimeter=0;" edge="1" parent="1" source="2" target="2">
+                <mxCell id="13" value="" style="endArrow=none;html=1;strokeColor=#5c93bb2b;strokeWidth=3;entryX=1;entryY=0.067;entryDx=0;entryDy=0;entryPerimeter=0;exitX=-0.001;exitY=0.069;exitDx=0;exitDy=0;exitPerimeter=0;" parent="1" source="2" target="2" edge="1">
                     <mxGeometry width="50" height="50" relative="1" as="geometry">
                         <mxPoint x="-0.4" y="70" as="sourcePoint"/>
                         <mxPoint x="1759.6" as="targetPoint"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="14" value="ロゴ" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=3;fillColor=#dae8fc;strokeColor=#6c8ebf;fontStyle=1;fontSize=26;labelBackgroundColor=none;fontColor=#301AF0;" vertex="1" parent="1">
+                <mxCell id="14" value="ロゴ" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=3;fillColor=#dae8fc;strokeColor=#6c8ebf;fontStyle=1;fontSize=26;labelBackgroundColor=none;fontColor=#301AF0;" parent="1" vertex="1">
                     <mxGeometry x="39.6" y="10" width="120" height="50" as="geometry"/>
                 </mxCell>
-                <mxCell id="15" value="ユーザー名 / テストテストテストテストテス" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;rounded=0;labelBackgroundColor=none;fontSize=18;fontColor=#000000d1;horizontal=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-                    <mxGeometry x="605" y="187" width="390" height="40" as="geometry"/>
+                <mxCell id="15" value="ユーザー名 / テストテストテストテストテス" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;rounded=0;labelBackgroundColor=none;fontSize=18;fontColor=#000000d1;horizontal=1;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+                    <mxGeometry x="605" y="190" width="390" height="40" as="geometry"/>
                 </mxCell>
-                <mxCell id="18" value="自己紹介メッセージ / テストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテ" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;rounded=0;labelBackgroundColor=none;fontSize=12;fontColor=#000000d1;horizontal=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-                    <mxGeometry x="605" y="220" width="390" height="60" as="geometry"/>
+                <mxCell id="18" value="自己紹介メッセージ / テストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテ" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;rounded=0;labelBackgroundColor=none;fontSize=12;fontColor=#000000d1;horizontal=1;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+                    <mxGeometry x="605" y="230" width="390" height="60" as="geometry"/>
                 </mxCell>
-                <mxCell id="23" value="フォロー中" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#FFFFFF;strokeColor=#3EA8FF;align=center;spacing=15;fontSize=14;fontColor=#3EA8FF;" vertex="1" parent="1">
-                    <mxGeometry x="1630" y="115" width="120" height="30" as="geometry"/>
+                <mxCell id="23" value="フォロー中" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#FFFFFF;strokeColor=#3EA8FF;align=center;spacing=15;fontSize=14;fontColor=#3EA8FF;" parent="1" vertex="1">
+                    <mxGeometry x="1050" y="120" width="120" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="22" value="フォロー" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#3EA8FF;strokeColor=#FFFFFF;align=center;spacing=15;fontSize=14;fontColor=#FFFFFF;fontStyle=1" vertex="1" parent="1">
-                    <mxGeometry x="1630" y="170" width="120" height="30" as="geometry"/>
+                <mxCell id="22" value="フォロー" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#3EA8FF;strokeColor=#FFFFFF;align=center;spacing=15;fontSize=14;fontColor=#FFFFFF;fontStyle=1" parent="1" vertex="1">
+                    <mxGeometry x="1050" y="170" width="120" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="20" value="&lt;font style=&quot;font-size: 12px&quot;&gt;プロフィール編集&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=#6c767d;align=center;spacing=15;fontSize=14;fontColor=#6c767d;" vertex="1" parent="1">
+                <mxCell id="20" value="&lt;font style=&quot;font-size: 12px&quot;&gt;プロフィール編集&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=#6c767d;align=center;spacing=15;fontSize=14;fontColor=#6c767d;" parent="1" vertex="1">
                     <mxGeometry x="870" y="150" width="120" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="25" value="" style="verticalLabelPosition=bottom;shadow=0;dashed=0;align=center;html=1;verticalAlign=top;strokeWidth=1;shape=mxgraph.mockup.containers.userFemale;strokeColor=#666666;strokeColor2=#008cff;fontSize=12;fontColor=#FFFFFF;fillColor=#3EA8FF;" vertex="1" parent="1">
+                <mxCell id="25" value="" style="verticalLabelPosition=bottom;shadow=0;dashed=0;align=center;html=1;verticalAlign=top;strokeWidth=1;shape=mxgraph.mockup.containers.userFemale;strokeColor=#666666;strokeColor2=#008cff;fontSize=12;fontColor=#FFFFFF;fillColor=#3EA8FF;" parent="1" vertex="1">
                     <mxGeometry x="610" y="90" width="90" height="90" as="geometry"/>
                 </mxCell>
-                <mxCell id="71" value="記事作成" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#3EA8FF;strokeColor=#FFFFFF;align=center;spacing=15;fontSize=14;fontColor=#FFFFFF;fontStyle=1" vertex="1" parent="1">
+                <mxCell id="71" value="記事作成" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#3EA8FF;strokeColor=#FFFFFF;align=center;spacing=15;fontSize=14;fontColor=#FFFFFF;fontStyle=1" parent="1" vertex="1">
                     <mxGeometry x="1445" y="15" width="120" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="72" value="" style="group" vertex="1" connectable="0" parent="1">
+                <mxCell id="72" value="" style="group" parent="1" vertex="1" connectable="0">
                     <mxGeometry x="-1.9999999999998863" y="330" width="1601.6" height="510" as="geometry"/>
                 </mxCell>
-                <mxCell id="26" value="" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;rSize=5;strokeColor=none;html=1;whiteSpace=wrap;fillColor=#FFFFFF;fontColor=#000000;fontSize=12;strokeWidth=1;align=center;" vertex="1" parent="72">
+                <mxCell id="26" value="" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;rSize=5;strokeColor=none;html=1;whiteSpace=wrap;fillColor=#FFFFFF;fontColor=#000000;fontSize=12;strokeWidth=1;align=center;" parent="72" vertex="1">
                     <mxGeometry x="434.9999999999999" width="730" height="510" as="geometry"/>
                 </mxCell>
-                <mxCell id="27" value="" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.topButton;strokeColor=inherit;fillColor=none;rSize=5;perimeter=none;whiteSpace=wrap;resizeWidth=1;align=center;spacing=20;fontSize=14;fontColor=#FFFFFF;" vertex="1" parent="26">
+                <mxCell id="27" value="" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.topButton;strokeColor=inherit;fillColor=none;rSize=5;perimeter=none;whiteSpace=wrap;resizeWidth=1;align=center;spacing=20;fontSize=14;fontColor=#FFFFFF;" parent="26" vertex="1">
                     <mxGeometry width="620" height="50" relative="1" as="geometry"/>
                 </mxCell>
-                <mxCell id="31" value="&lt;span style=&quot;font-size: 20px&quot;&gt;&lt;b&gt;レシピ一覧&lt;/b&gt;&lt;/span&gt;" style="perimeter=none;html=1;whiteSpace=wrap;fillColor=none;strokeColor=none;resizeWidth=1;verticalAlign=top;align=left;spacing=20;spacingTop=-10;fontSize=14;fontColor=#212529;dashed=1;" vertex="1" parent="26">
+                <mxCell id="31" value="&lt;span style=&quot;font-size: 20px&quot;&gt;&lt;b&gt;レシピ一覧&lt;/b&gt;&lt;/span&gt;" style="perimeter=none;html=1;whiteSpace=wrap;fillColor=none;strokeColor=none;resizeWidth=1;verticalAlign=top;align=left;spacing=20;spacingTop=-10;fontSize=14;fontColor=#212529;dashed=1;" parent="26" vertex="1">
                     <mxGeometry width="620" height="120" relative="1" as="geometry">
                         <mxPoint y="50" as="offset"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="56" value="" style="group" vertex="1" connectable="0" parent="26">
+                <mxCell id="56" value="" style="group" parent="26" vertex="1" connectable="0">
                     <mxGeometry x="65" y="120" width="600" height="180" as="geometry"/>
                 </mxCell>
-                <mxCell id="40" value="" style="shadow=0;dashed=0;shape=mxgraph.bootstrap.rightButton;rSize=5;strokeColor=#DFDFDF;fillColor=#ffffff;fontColor=#000000;verticalAlign=top;align=left;spacing=20;spacingBottom=0;fontSize=14;spacingTop=160;" vertex="1" parent="56">
+                <mxCell id="40" value="" style="shadow=0;dashed=0;shape=mxgraph.bootstrap.rightButton;rSize=5;strokeColor=#DFDFDF;fillColor=#ffffff;fontColor=#000000;verticalAlign=top;align=left;spacing=20;spacingBottom=0;fontSize=14;spacingTop=160;" parent="56" vertex="1">
                     <mxGeometry width="180" height="180" as="geometry">
                         <mxPoint x="-10" y="-210" as="offset"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="41" value="Image cap" style="html=1;shadow=0;dashed=0;shape=mxgraph.basic.corner_round_rect;dx=2;flipH=1;perimeter=none;whiteSpace=wrap;fillColor=#3EA8FF;strokeColor=#DFDFDF;fontColor=#DEE2E6;resizeWidth=1;fontSize=18;" vertex="1" parent="40">
+                <mxCell id="41" value="Image cap" style="html=1;shadow=0;dashed=0;shape=mxgraph.basic.corner_round_rect;dx=2;flipH=1;perimeter=none;whiteSpace=wrap;fillColor=#3EA8FF;strokeColor=#DFDFDF;fontColor=#DEE2E6;resizeWidth=1;fontSize=18;" parent="40" vertex="1">
                     <mxGeometry width="180" height="50" relative="1" as="geometry"/>
                 </mxCell>
-                <mxCell id="52" value="" style="shadow=0;dashed=0;shape=mxgraph.bootstrap.rightButton;rSize=5;strokeColor=#DFDFDF;fillColor=#ffffff;fontColor=#000000;verticalAlign=top;align=left;spacing=20;spacingBottom=0;fontSize=14;spacingTop=160;" vertex="1" parent="56">
+                <mxCell id="52" value="" style="shadow=0;dashed=0;shape=mxgraph.bootstrap.rightButton;rSize=5;strokeColor=#DFDFDF;fillColor=#ffffff;fontColor=#000000;verticalAlign=top;align=left;spacing=20;spacingBottom=0;fontSize=14;spacingTop=160;" parent="56" vertex="1">
                     <mxGeometry x="210" width="180" height="180" as="geometry">
                         <mxPoint x="-10" y="-210" as="offset"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="53" value="Image cap" style="html=1;shadow=0;dashed=0;shape=mxgraph.basic.corner_round_rect;dx=2;flipH=1;perimeter=none;whiteSpace=wrap;fillColor=#3EA8FF;strokeColor=#DFDFDF;fontColor=#DEE2E6;resizeWidth=1;fontSize=18;" vertex="1" parent="52">
+                <mxCell id="53" value="Image cap" style="html=1;shadow=0;dashed=0;shape=mxgraph.basic.corner_round_rect;dx=2;flipH=1;perimeter=none;whiteSpace=wrap;fillColor=#3EA8FF;strokeColor=#DFDFDF;fontColor=#DEE2E6;resizeWidth=1;fontSize=18;" parent="52" vertex="1">
                     <mxGeometry width="180" height="50" relative="1" as="geometry"/>
                 </mxCell>
-                <mxCell id="54" value="" style="shadow=0;dashed=0;shape=mxgraph.bootstrap.rightButton;rSize=5;strokeColor=#DFDFDF;fillColor=#ffffff;fontColor=#000000;verticalAlign=top;align=left;spacing=20;spacingBottom=0;fontSize=14;spacingTop=160;" vertex="1" parent="56">
+                <mxCell id="54" value="" style="shadow=0;dashed=0;shape=mxgraph.bootstrap.rightButton;rSize=5;strokeColor=#DFDFDF;fillColor=#ffffff;fontColor=#000000;verticalAlign=top;align=left;spacing=20;spacingBottom=0;fontSize=14;spacingTop=160;" parent="56" vertex="1">
                     <mxGeometry x="420" width="180" height="180" as="geometry">
                         <mxPoint x="-10" y="-210" as="offset"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="55" value="Image cap" style="html=1;shadow=0;dashed=0;shape=mxgraph.basic.corner_round_rect;dx=2;flipH=1;perimeter=none;whiteSpace=wrap;fillColor=#3EA8FF;strokeColor=#DFDFDF;fontColor=#DEE2E6;resizeWidth=1;fontSize=18;" vertex="1" parent="54">
+                <mxCell id="55" value="Image cap" style="html=1;shadow=0;dashed=0;shape=mxgraph.basic.corner_round_rect;dx=2;flipH=1;perimeter=none;whiteSpace=wrap;fillColor=#3EA8FF;strokeColor=#DFDFDF;fontColor=#DEE2E6;resizeWidth=1;fontSize=18;" parent="54" vertex="1">
                     <mxGeometry width="180" height="50" relative="1" as="geometry"/>
                 </mxCell>
-                <mxCell id="64" value="" style="group" vertex="1" connectable="0" parent="26">
+                <mxCell id="64" value="" style="group" parent="26" vertex="1" connectable="0">
                     <mxGeometry x="65" y="330" width="600" height="180" as="geometry"/>
                 </mxCell>
-                <mxCell id="65" value="" style="shadow=0;dashed=0;shape=mxgraph.bootstrap.rightButton;rSize=5;strokeColor=#DFDFDF;fillColor=#ffffff;fontColor=#000000;verticalAlign=top;align=left;spacing=20;spacingBottom=0;fontSize=14;spacingTop=160;" vertex="1" parent="64">
+                <mxCell id="65" value="" style="shadow=0;dashed=0;shape=mxgraph.bootstrap.rightButton;rSize=5;strokeColor=#DFDFDF;fillColor=#ffffff;fontColor=#000000;verticalAlign=top;align=left;spacing=20;spacingBottom=0;fontSize=14;spacingTop=160;" parent="64" vertex="1">
                     <mxGeometry width="180" height="180" as="geometry">
                         <mxPoint x="-10" y="-210" as="offset"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="66" value="Image cap" style="html=1;shadow=0;dashed=0;shape=mxgraph.basic.corner_round_rect;dx=2;flipH=1;perimeter=none;whiteSpace=wrap;fillColor=#3EA8FF;strokeColor=#DFDFDF;fontColor=#DEE2E6;resizeWidth=1;fontSize=18;" vertex="1" parent="65">
+                <mxCell id="66" value="Image cap" style="html=1;shadow=0;dashed=0;shape=mxgraph.basic.corner_round_rect;dx=2;flipH=1;perimeter=none;whiteSpace=wrap;fillColor=#3EA8FF;strokeColor=#DFDFDF;fontColor=#DEE2E6;resizeWidth=1;fontSize=18;" parent="65" vertex="1">
                     <mxGeometry width="180" height="50" relative="1" as="geometry"/>
                 </mxCell>
-                <mxCell id="67" value="" style="shadow=0;dashed=0;shape=mxgraph.bootstrap.rightButton;rSize=5;strokeColor=#DFDFDF;fillColor=#ffffff;fontColor=#000000;verticalAlign=top;align=left;spacing=20;spacingBottom=0;fontSize=14;spacingTop=160;" vertex="1" parent="64">
+                <mxCell id="67" value="" style="shadow=0;dashed=0;shape=mxgraph.bootstrap.rightButton;rSize=5;strokeColor=#DFDFDF;fillColor=#ffffff;fontColor=#000000;verticalAlign=top;align=left;spacing=20;spacingBottom=0;fontSize=14;spacingTop=160;" parent="64" vertex="1">
                     <mxGeometry x="210" width="180" height="180" as="geometry">
                         <mxPoint x="-10" y="-210" as="offset"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="68" value="Image cap" style="html=1;shadow=0;dashed=0;shape=mxgraph.basic.corner_round_rect;dx=2;flipH=1;perimeter=none;whiteSpace=wrap;fillColor=#3EA8FF;strokeColor=#DFDFDF;fontColor=#DEE2E6;resizeWidth=1;fontSize=18;" vertex="1" parent="67">
+                <mxCell id="68" value="Image cap" style="html=1;shadow=0;dashed=0;shape=mxgraph.basic.corner_round_rect;dx=2;flipH=1;perimeter=none;whiteSpace=wrap;fillColor=#3EA8FF;strokeColor=#DFDFDF;fontColor=#DEE2E6;resizeWidth=1;fontSize=18;" parent="67" vertex="1">
                     <mxGeometry width="180" height="50" relative="1" as="geometry"/>
                 </mxCell>
-                <mxCell id="69" value="" style="shadow=0;dashed=0;shape=mxgraph.bootstrap.rightButton;rSize=5;strokeColor=#DFDFDF;fillColor=#ffffff;fontColor=#000000;verticalAlign=top;align=left;spacing=20;spacingBottom=0;fontSize=14;spacingTop=160;" vertex="1" parent="64">
+                <mxCell id="69" value="" style="shadow=0;dashed=0;shape=mxgraph.bootstrap.rightButton;rSize=5;strokeColor=#DFDFDF;fillColor=#ffffff;fontColor=#000000;verticalAlign=top;align=left;spacing=20;spacingBottom=0;fontSize=14;spacingTop=160;" parent="64" vertex="1">
                     <mxGeometry x="420" width="180" height="180" as="geometry">
                         <mxPoint x="-10" y="-210" as="offset"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="70" value="Image cap" style="html=1;shadow=0;dashed=0;shape=mxgraph.basic.corner_round_rect;dx=2;flipH=1;perimeter=none;whiteSpace=wrap;fillColor=#3EA8FF;strokeColor=#DFDFDF;fontColor=#DEE2E6;resizeWidth=1;fontSize=18;" vertex="1" parent="69">
+                <mxCell id="70" value="Image cap" style="html=1;shadow=0;dashed=0;shape=mxgraph.basic.corner_round_rect;dx=2;flipH=1;perimeter=none;whiteSpace=wrap;fillColor=#3EA8FF;strokeColor=#DFDFDF;fontColor=#DEE2E6;resizeWidth=1;fontSize=18;" parent="69" vertex="1">
                     <mxGeometry width="180" height="50" relative="1" as="geometry"/>
                 </mxCell>
-                <mxCell id="28" value="レシピ" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.tabTop;strokeColor=#DFDFDF;fillColor=#ffffff;rSize=5;perimeter=none;resizeWidth=1;align=center;spacing=20;fontSize=14;fontColor=#3EA8FF;" vertex="1" parent="26">
+                <mxCell id="28" value="レシピ" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.tabTop;strokeColor=#DFDFDF;fillColor=#ffffff;rSize=5;perimeter=none;resizeWidth=1;align=center;spacing=20;fontSize=14;fontColor=#3EA8FF;" parent="26" vertex="1">
                     <mxGeometry width="62" height="40" relative="1" as="geometry">
                         <mxPoint x="10" y="11" as="offset"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="34" value="" style="endArrow=none;html=1;strokeColor=#dfdfdf;strokeWidth=1;entryX=1;entryY=0.067;entryDx=0;entryDy=0;entryPerimeter=0;exitX=-0.001;exitY=0.069;exitDx=0;exitDy=0;exitPerimeter=0;" edge="1" parent="72">
+                <mxCell id="78" value="スキル" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.tabTop;strokeColor=#DFDFDF;fillColor=#ffffff;rSize=5;perimeter=none;resizeWidth=1;align=center;spacing=20;fontSize=14;fontColor=#6C767D;" parent="26" vertex="1">
+                    <mxGeometry x="73" y="10" width="62" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="34" value="" style="endArrow=none;html=1;strokeColor=#dfdfdf;strokeWidth=1;entryX=1;entryY=0.067;entryDx=0;entryDy=0;entryPerimeter=0;exitX=-0.001;exitY=0.069;exitDx=0;exitDy=0;exitPerimeter=0;" parent="72" edge="1">
                     <mxGeometry width="50" height="50" relative="1" as="geometry">
                         <mxPoint y="51.80000000000001" as="sourcePoint"/>
                         <mxPoint x="1601.6" y="49.99999999999994" as="targetPoint"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="77" value="" style="group" vertex="1" connectable="0" parent="1">
-                    <mxGeometry x="603" y="290" width="395" height="30" as="geometry"/>
+                <mxCell id="77" value="" style="group" parent="1" vertex="1" connectable="0">
+                    <mxGeometry x="603" y="300" width="395" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="75" value="&lt;font style=&quot;font-size: 12px&quot;&gt;投稿 6&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=none;align=center;spacing=15;fontSize=12;fontColor=#6c767d;" vertex="1" parent="77">
+                <mxCell id="75" value="&lt;font style=&quot;font-size: 12px&quot;&gt;投稿 6&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=none;align=center;spacing=15;fontSize=12;fontColor=#6c767d;" parent="77" vertex="1">
                     <mxGeometry width="130" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="76" value="&lt;font style=&quot;font-size: 12px&quot;&gt;フォロー 50&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=none;align=center;spacing=15;fontSize=12;fontColor=#6c767d;" vertex="1" parent="77">
+                <mxCell id="76" value="&lt;font style=&quot;font-size: 12px&quot;&gt;フォロー 50&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=none;align=center;spacing=15;fontSize=12;fontColor=#6c767d;" parent="77" vertex="1">
                     <mxGeometry x="130" width="130" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="74" value="&lt;font style=&quot;font-size: 12px&quot;&gt;フォロワー 50&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=none;align=center;spacing=15;fontSize=12;fontColor=#6c767d;" vertex="1" parent="77">
+                <mxCell id="74" value="&lt;font style=&quot;font-size: 12px&quot;&gt;フォロワー 50&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=none;align=center;spacing=15;fontSize=12;fontColor=#6c767d;" parent="77" vertex="1">
                     <mxGeometry x="260" width="130" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="85" value="" style="shape=curlyBracket;whiteSpace=wrap;html=1;rounded=1;dashed=1;labelBackgroundColor=none;fontSize=12;fontColor=#666666;strokeColor=#000000;strokeWidth=1;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="1000" y="130" width="50" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="86" value="表示しているユーザーによってボタンが変わる&lt;br&gt;（自分なら「編集」、未フォローの他人なら「フォロー」）" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;dashed=1;labelBackgroundColor=none;fontSize=12;fontColor=#666666;" vertex="1" parent="1">
+                    <mxGeometry x="930" y="80" width="430" height="30" as="geometry"/>
                 </mxCell>
             </root>
         </mxGraphModel>

--- a/documents/ScreenDesigns/プロフィール表示画面.drawio
+++ b/documents/ScreenDesigns/プロフィール表示画面.drawio
@@ -116,11 +116,8 @@
                         <mxPoint x="1601.6" y="49.99999999999994" as="targetPoint"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="73" value="&lt;font style=&quot;font-size: 12px&quot;&gt;50 フォロワー&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=none;align=center;spacing=15;fontSize=12;fontColor=#6c767d;" vertex="1" parent="1">
-                    <mxGeometry x="740" y="300" width="120" height="30" as="geometry"/>
-                </mxCell>
                 <mxCell id="77" value="" style="group" vertex="1" connectable="0" parent="1">
-                    <mxGeometry x="603" y="300" width="395" height="30" as="geometry"/>
+                    <mxGeometry x="603" y="290" width="395" height="30" as="geometry"/>
                 </mxCell>
                 <mxCell id="75" value="&lt;font style=&quot;font-size: 12px&quot;&gt;投稿 6&lt;/font&gt;" style="html=1;shadow=0;dashed=1;shape=mxgraph.bootstrap.rrect;rSize=5;fillColor=#fff;strokeColor=none;align=center;spacing=15;fontSize=12;fontColor=#6c767d;" vertex="1" parent="77">
                     <mxGeometry width="130" height="30" as="geometry"/>


### PR DESCRIPTION
お疲れ様です！
プロフィール画面及び編集画面イメージについて作成したので確認よろしくお願いします🙇‍♂️

## プロフィール表示画面について
プロフィール表示画面に表示される要素は以下の通りです。
- ユーザー名
- 自己紹介
- 投稿数
- フォロー数
- フォロワー数
- プロフィール編集/フォロー/フォロー解除ボタン
  - ユーザー本人のプロフィールであれば「編集」、他人であれば「フォロー」又は「フォロー解除」ボタンを表示する想定です

※レシピの表示枠とスキルのタブがありますが最初に作成する最低限のサービスとしては不要な気がするのでスルーしてもらってもいいかもです（作ってから気づきました...次回のデイリースクラムでも相談してみようかと思います）

## プロフィール編集画面について
プロフィール編集画面については、以下の作業を行うことを想定しています
- ユーザー名の変更
- 自己紹介文の変更
- 退会処理