### PR TITLE
レシピ閲覧機能の実装

### DIFF
--- a/application/app/Http/Controllers/PostController.php
+++ b/application/app/Http/Controllers/PostController.php
@@ -41,4 +41,14 @@ class PostController extends Controller
             'keyword' => $keyword,
         ]);
     }
+    /**
+     * Display the specified resource.
+     *
+     * @param  \App\Models\Post  $post
+     * @return \Illuminate\Http\Response
+     */
+    public function show(Post $post)
+    {
+        return view('posts.show', ['post' => $post]);
+    }
 }

--- a/application/app/Http/Controllers/PostController.php
+++ b/application/app/Http/Controllers/PostController.php
@@ -49,6 +49,10 @@ class PostController extends Controller
      */
     public function show(Post $post)
     {
-        return view('posts.show', ['post' => $post]);
+        $interval = $post->updated_at->diff(now());
+        return view('posts.show', [
+            'post' => $post,
+            'interval' => $interval
+        ]);
     }
 }

--- a/application/database/factories/AttachmentFileFactory.php
+++ b/application/database/factories/AttachmentFileFactory.php
@@ -22,11 +22,10 @@ class AttachmentFileFactory extends Factory
      */
     public function definition()
     {
-        //ダミーファイル保存用の記述
-        $storage_name = 'attachment_pic'; //ストレージとするディレクトリ名を記述する
-        $storage_dir_path = Storage::disk('local')->path('public/'.$storage_name);
-        if(Storage::disk('local')->missing('public/'.$storage_name)){
-            Storage::makeDirectory('public/'.$storage_name);
+        $storage_dir_name = 'attachment_pic'; //ストレージとするディレクトリ名
+        $storage_dir_path = Storage::disk('local')->path('public/'.$storage_dir_name);
+        if(Storage::disk('local')->missing('public/'.$storage_dir_name)){
+            Storage::makeDirectory('public/'.$storage_dir_name);
         }
         $picture = $this->faker->image($storage_dir_path, 620, 325, 'city', false);
         $file_path = str_replace($storage_dir_path, '', $picture);

--- a/application/database/factories/AttachmentFileFactory.php
+++ b/application/database/factories/AttachmentFileFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use App\Models\AttachmentFile;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Storage;
 
 class AttachmentFileFactory extends Factory
 {
@@ -21,8 +22,17 @@ class AttachmentFileFactory extends Factory
      */
     public function definition()
     {
+        //ダミーファイル保存用の記述
+        $storage_name = 'attachment_pic'; //ストレージとするディレクトリ名を記述する
+        $storage_dir_path = Storage::disk('local')->path('public/'.$storage_name);
+        if(Storage::disk('local')->missing('public/'.$storage_name)){
+            Storage::makeDirectory('public/'.$storage_name);
+        }
+        $picture = $this->faker->image($storage_dir_path, 620, 325, 'city', false);
+        $file_path = str_replace($storage_dir_path, '', $picture);
+
         return [
-        'attachment_pic_path' => $this->faker->url
+        'attachment_pic_path' => $file_path,
         ];
     }
 }

--- a/application/resources/views/posts/show.blade.php
+++ b/application/resources/views/posts/show.blade.php
@@ -13,9 +13,9 @@
                 <div class="pl-2">
                     <p class="text-xs">{{$post->user->name}}</p>
                     <p class="text-xs text-gray-500">
-                        @if ($interval->days === 0 && $interval->h === 0)
+                        @if ($interval->days < 1 && $interval->h === 0)
                             {{$interval->i}}分前
-                        @elseif ($interval->days === 0)
+                        @elseif ($interval->days < 1)
                             {{$interval->h}}時間前
                         @else
                             {{$post->updated_at->format('Y年m月d日')}}

--- a/application/resources/views/posts/show.blade.php
+++ b/application/resources/views/posts/show.blade.php
@@ -1,0 +1,24 @@
+<x-app-layout>
+    <x-slot name="header"></x-slot>
+    <article class="max-w-4xl mx-auto px-10">
+        <header class="flex flex-col px-24">
+            <div class="w-2xl h-80 py-12">
+                {{-- @todo 画像表示方法の確認→修正 --}}
+                <x-eye-chacher src="{{$post->attachment->attachment_pic_path}}"></x-eye-chacher>
+            </div>
+            <h1 class="pb-12 text-3xl font-bold">{{$post->title}}</h1>
+            <div class="flex pb-12">
+                <div class="flex-shrink-0 w-8 h-8">
+                    <x-profile-pic src="/storage/profile_pic/{{$post->user->profile_pic_path}}"></x-profile-pic>
+                </div>
+                <div class="pl-2">
+                    <p class="text-xs">{{$post->user->name}}</p>
+                    <p class="text-xs">{{$post->updated_at}}</p>
+                </div>
+            </div>
+        </header>
+        <div class="rounded-md border-transparent bg-white py-16 px-20">
+            {{$post->content}}
+        </div>
+    </article>
+</x-app-layout>

--- a/application/resources/views/posts/show.blade.php
+++ b/application/resources/views/posts/show.blade.php
@@ -2,9 +2,8 @@
     <x-slot name="header"></x-slot>
     <article class="max-w-4xl mx-auto px-10">
         <header class="flex flex-col px-24">
-            <div class="w-2xl h-80 py-12">
-                {{-- @todo 画像表示方法の確認→修正 --}}
-                <x-eye-chacher src="{{$post->attachment->attachment_pic_path}}"></x-eye-chacher>
+            <div class="w-2xl h-80 my-12">
+                <x-eye-chacher src="/storage/attachment_pic/{{$post->attachment->attachment_pic_path}}"></x-eye-chacher>
             </div>
             <h1 class="pb-12 text-3xl font-bold">{{$post->title}}</h1>
             <div class="flex pb-12">
@@ -13,11 +12,19 @@
                 </div>
                 <div class="pl-2">
                     <p class="text-xs">{{$post->user->name}}</p>
-                    <p class="text-xs">{{$post->updated_at}}</p>
+                    <p class="text-xs text-gray-500">
+                        @if ($interval->days === 0 && $interval->h === 0)
+                            {{$interval->i}}分前
+                        @elseif ($interval->days === 0)
+                            {{$interval->h}}時間前
+                        @else
+                            {{$post->updated_at->format('Y年m月d日')}}
+                        @endif
+                    </p>
                 </div>
             </div>
         </header>
-        <div class="rounded-md border-transparent bg-white py-16 px-20">
+        <div class="rounded-md border-transparent bg-white py-16 px-20 mb-20">
             {{$post->content}}
         </div>
     </article>

--- a/application/routes/web.php
+++ b/application/routes/web.php
@@ -25,6 +25,5 @@ Route::resource('users', UserController::class)->only([
 ]);
 
 //Post用
-    Route::resource('posts', PostController::class);
-    //@check 表示確認のため表示機能実装作業中のみ無効化。
-    // ->middleware(['auth']);
+    Route::resource('posts', PostController::class)
+    ->middleware(['auth']);

--- a/application/routes/web.php
+++ b/application/routes/web.php
@@ -25,5 +25,6 @@ Route::resource('users', UserController::class)->only([
 ]);
 
 //Post用
-    Route::resource('posts', PostController::class)
-    ->middleware(['auth']);
+    Route::resource('posts', PostController::class);
+    //@check 表示確認のため表示機能実装作業中のみ無効化。
+    // ->middleware(['auth']);


### PR DESCRIPTION
お疲れ様です。
レシピを閲覧できる機能を実装しましたのでご確認よろしくお願いします！

## 実装内容
レシピ閲覧画面を表示できるようにしました

## 期待する動作
- 投稿されたレシピ閲覧画面にアクセスすることができる（http://localhost:10780/posts/{id}）
- レシピ閲覧画面に以下の項目が表示される
	- サムネイル画像
	- レシピのタイトル
	- 投稿したユーザー名
	- ユーザーのプロフィール画像
	- 更新日時
	  - -分前（更新日時が現在時刻と比較して１時間以内の場合）
	  -  -時間前（更新日時が現在時刻と比較して１日以内の場合）
	  -  年月日（更新日時が現在時刻と比較して２日以上前の場合）
	- 記事の内容

## 確認方法
1. `web.php`で`Post用`のルーティングから`->middleware(['auth'])`の記述をコメントアウトする。
    - ※現在ヘッダーが未完成でログイン画面にアクセスする手段が存在しないため、認証機能を切っておく必要がある
2. `http://localhost:10780/posts/{id}`にアクセスする
    - `{id}`には任意の記事idを入力する
3. #期待される動作 に記載した項目が全て表示されていることを確認する
4. アクセスしている記事に対して、phpmyadminで`updated_at`カラムを以下の通り編集し期待通りの表示になるか確認する
    - `updated_at`を現在時刻から1時間以内に変更：`-分前`と表示される
    - `updated_at`を現在時刻から1日以内に変更：`-時間前`と表示される
    - `updated_at`を現在時刻から2日以上前に変更：年月日が表示される
