### PR TITLE
レシピ投稿機能の作成

### DIFF
--- a/application/app/Http/Controllers/PostController.php
+++ b/application/app/Http/Controllers/PostController.php
@@ -34,6 +34,33 @@ class PostController extends Controller
             'pic_exist' => $pic_exist
         ]);
     }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \app\Http\Requests\StorePostRequest  $request
+     * @param  \App\Models\Post  $post
+     * @return \Illuminate\Http\Response
+     */
+    public function store(StorePostRequest $request)
+    {
+        $validated = $request->validated();
+
+        if ($post = Post::create([
+            'title' => $validated['title'],
+            'content' => $validated['content'],
+            'created_user_id' => $request->user()->id,
+        ])) {
+            $flash = "";
+        } else {
+            $flash = ['error' => __('Failed to store the post.')];
+        }
+
+        return redirect()
+            ->route('posts.edit', ['post' => $post])
+            ->with($flash);
+    }
+
     /**
      * Display a listing of the resource.
      *
@@ -64,6 +91,7 @@ class PostController extends Controller
             'keyword' => $keyword,
         ]);
     }
+
     /**
      * Display the specified resource.
      *
@@ -90,7 +118,7 @@ class PostController extends Controller
         $storage_dir_name = 'attachment_pic'; //ストレージのディレクトリ名
         if(isset($post->attachment)){
             $pic_exist = Storage::disk('public')
-            ->exists($storage_dir_name.'/'.$post->attachment->attachment_pic_path);
+                ->exists($storage_dir_name.'/'.$post->attachment->attachment_pic_path);
         }else{
             $pic_exist = "";
         }

--- a/application/app/Http/Controllers/PostController.php
+++ b/application/app/Http/Controllers/PostController.php
@@ -21,8 +21,14 @@ class PostController extends Controller
     public function create(Post $post)
     {
         $storage_dir_name = 'attachment_pic'; //ストレージのディレクトリ名
-        $pic_exist = Storage::disk('public')
+        // @todo 以下の処理は後ほどモデルに移す
+        if(isset($post->attachment)){
+            $pic_exist = Storage::disk('public')
             ->exists($storage_dir_name.'/'.$post->attachment->attachment_pic_path);
+        }else{
+            $pic_exist = "";
+        }
+
         return view('posts.create', [
             'post' => $post,
             'pic_exist' => $pic_exist
@@ -82,8 +88,13 @@ class PostController extends Controller
     public function edit(Post $post)
     {
         $storage_dir_name = 'attachment_pic'; //ストレージのディレクトリ名
-        $pic_exist = Storage::disk('public')
+        if(isset($post->attachment)){
+            $pic_exist = Storage::disk('public')
             ->exists($storage_dir_name.'/'.$post->attachment->attachment_pic_path);
+        }else{
+            $pic_exist = "";
+        }
+
         return view('posts.edit', [
             'post' => $post,
             'pic_exist' => $pic_exist

--- a/application/app/Http/Controllers/TmpFileController.php
+++ b/application/app/Http/Controllers/TmpFileController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Rules\AttachmentFileValidation;
 
 class TmpFileController extends Controller
 {
@@ -13,9 +14,11 @@ class TmpFileController extends Controller
      */
     public function storeTmpFile(Request $request)
     {
+        $request->validate([
+            'file' => ['required', 'file', new AttachmentFileValidation]
+        ]);
         //投稿予定画像がある場合、tmpディレクトリに画像を保存し、セッション情報を一時的に保持する
         if($file = $request->file('file')){
-            $tmp_file_name = $file->hashName();
             $tmp_file_path = basename($file->store('public/tmp'));
             $request->session()->put('tmp_file', $tmp_file_path);
 

--- a/application/app/Http/Controllers/TmpFileController.php
+++ b/application/app/Http/Controllers/TmpFileController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class TmpFileController extends Controller
+{
+    /**
+     * store the picture temporarily.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function storeTmpFile(Request $request)
+    {
+        //投稿予定画像がある場合、tmpディレクトリに画像を保存し、セッション情報を一時的に保持する
+        if($file = $request->file('file')){
+            $tmp_file_name = $file->hashName();
+            $tmp_file_path = basename($file->store('public/tmp'));
+            $request->session()->put('tmp_file', $tmp_file_path);
+
+            $flash = ['success' => __('File added successfully.')];
+        } else {
+            $flash = ['error' => __('Failed to add the file.')];
+        }
+        return redirect()
+            ->route('posts.create')
+            ->with($flash);
+    }
+}

--- a/application/database/factories/AttachmentFileFactory.php
+++ b/application/database/factories/AttachmentFileFactory.php
@@ -25,7 +25,7 @@ class AttachmentFileFactory extends Factory
         $storage_dir_name = 'attachment_pic'; //ストレージとするディレクトリ名
         $storage_dir_path = Storage::disk('public')->path($storage_dir_name);
         if(Storage::disk('public')->missing($storage_dir_name)){
-            Storage::disc('public')->makeDirectory($storage_dir_name);
+            Storage::disk('public')->makeDirectory($storage_dir_name);
         }
         $picture = $this->faker->image($storage_dir_path, 620, 325, 'city', false);
         $file_path = str_replace($storage_dir_path, '', $picture);

--- a/application/database/factories/UserFactory.php
+++ b/application/database/factories/UserFactory.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Storage;
 
 class UserFactory extends Factory
 {
@@ -23,8 +24,12 @@ class UserFactory extends Factory
      */
     public function definition()
     {
-        //ダミープロフィール画像保存用の記述
-        $storage_dir_path = './storage/app/public/profile_pic';
+        $storage_dir_name = 'profile_pic'; //ストレージとするディレクトリ名
+        $storage_dir_path = Storage::disk('public')->path($storage_dir_name);
+        if(Storage::disk('public')->missing($storage_dir_name)){
+            Storage::disk('public')->makeDirectory($storage_dir_name);
+        }
+
         $picture = $this->faker->image($storage_dir_path, 300, 300, 'people', false);
         $file_path = str_replace($storage_dir_path, '', $picture);
 

--- a/application/resources/views/posts/create.blade.php
+++ b/application/resources/views/posts/create.blade.php
@@ -20,7 +20,7 @@
             </form>
         </div>
         <div class="w-full">
-            <form method="POST" action="{{ route('posts.create', ['post' => $post]) }}">
+            <form method="POST" action="{{ route('posts.store', ['post' => $post]) }}">
                 @csrf
                 <div class="px-24">
                     <x-textarea name="title" class="w-full bg-transparent text-3xl font-bold leading-10" value="{{$post->title}}" placeholder="タイトル"  rows="2" maxlength="255"/>

--- a/application/resources/views/posts/create.blade.php
+++ b/application/resources/views/posts/create.blade.php
@@ -1,3 +1,18 @@
+@section('script')
+<script>
+    let file = document.getElementById('file');
+    file.addEventListener('change', function(event){
+        const file = event.target.files[0];
+
+        if(typeof event.target.files[0] !== 'undefined') {
+            document.forms['uploadform'].submit();
+        } else {
+            // @fixme ほんとはファイルアップロード失敗時の処理も書いておくといいが省略
+        }
+    }, false);
+</script>
+@endsection
+
 <x-app-layout>
     <x-slot name="header"></x-slot>
     <!-- Validation Errors -->
@@ -5,12 +20,12 @@
     <x-validation-errors :errors="$errors" />
     <article class="w-screen max-w-4xl mx-auto px-10">
         <div class="flex flex-col px-24">
-            <form name="uploadform" method="POST" action="{{ route('posts.create', ['post' => $post->id, 'attachment_file' => $post->attachment ]) }}" enctype="multipart/form-data">
+            <form name="uploadform" method="POST" action="{{ route('posts.storeTmpFile') }}" enctype="multipart/form-data">
                 @csrf
                 <div class="w-2xl my-12">
                     <label for="file">
-                    @if($pic_exist)
-                        <x-eye-chacher src="{{ asset('storage/attachment_pic/'.$post->attachment->attachment_pic_path)}}" alt="サムネイル" class="h-80 mx-auto cursor-pointer" />
+                    @if($tmp_file = session('tmp_file'))
+                        <x-eye-chacher src="{{ asset('storage/tmp/'.$tmp_file)}}" alt="サムネイル" class="h-80 mx-auto cursor-pointer" />
                     @else
                         <x-upload-icon class="w-12 h-12 cursor-pointer" />
                     @endif
@@ -26,6 +41,7 @@
                     <x-textarea name="title" class="w-full bg-transparent text-3xl font-bold leading-10" value="{{$post->title}}" placeholder="タイトル"  rows="2" maxlength="255"/>
                 </div>
                 <x-textarea name="content" class="w-full h-screen bg-white py-16 px-20 mb-20" :value="old('content', $post->content)" placeholder="学習で成功した体験をレシピとして投稿してみませんか？" maxlength="10000" />
+                <x-submit-button-main>テスト</x-submit-button-main>
             </form>
         </div>
     </article>

--- a/application/resources/views/posts/create.blade.php
+++ b/application/resources/views/posts/create.blade.php
@@ -41,7 +41,6 @@
                     <x-textarea name="title" class="w-full bg-transparent text-3xl font-bold leading-10" value="{{$post->title}}" placeholder="タイトル"  rows="2" maxlength="255"/>
                 </div>
                 <x-textarea name="content" class="w-full h-screen bg-white py-16 px-20 mb-20" :value="old('content', $post->content)" placeholder="学習で成功した体験をレシピとして投稿してみませんか？" maxlength="10000" />
-                <x-submit-button-main>テスト</x-submit-button-main>
             </form>
         </div>
     </article>

--- a/application/routes/web.php
+++ b/application/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\AttachmentFileController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\PostController;
+use App\Http\Controllers\TmpFileController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -27,6 +28,10 @@ Route::resource('users', UserController::class)->only([
 
 //Post用
 Route::resource('posts', PostController::class)
+    ->middleware(['auth']);
+
+Route::post('posts/storeTmpFile', [TmpFileController::class, 'storeTmpFile'])
+    ->name('posts.storeTmpFile')
     ->middleware(['auth']);
 
 Route::resource('posts/{post}/attachment_files', AttachmentFileController::class)


### PR DESCRIPTION
## 実装内容
- レシピ投稿画面を表示できるようにしました
- レシピを投稿できるようにしました
- サムネイル画像を登録できるようにしました

## 期待する動作
- レシピ登録画面にアクセスすることができる（[http://localhost:10780/posts/{id}/edit）]
- レシピ登録画面に以下の入力欄が表示される
  - サムネイル画像
  - レシピのタイトル
  - 記事の内容
- サムネイル画像をクリックするとファイルアップロードが起動し、画像を登録することができる
  - 更新可能なファイル形式はJPEG、GIF、PNG、TIFF
  - 容量は10.05MB以内（10.05MBまではファインダー等で「10.0MB」と表示されるため）
  - 上記２つを満たさない画像がアップロードされたときはエラーメッセージが表示される
- 記述したタイトル、記事の内容投稿することができる
  - タイトル：255文字以内
  - 記事の内容：10000文字以内

## 未完成な部分
- セッションに保存したファイルパスを破棄する処理
- 一時保存した画像を定期的に削除する処理
